### PR TITLE
Update ProgressLoggingExternalResourceAccessor.java

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessor.java
@@ -58,7 +58,7 @@ public class ProgressLoggingExternalResourceAccessor extends AbstractProgressLog
     private BuildOperationDescriptor.Builder createBuildOperationDetails(ExternalResourceName resourceName) {
         ExternalResourceReadBuildOperationType.Details operationDetails = new ReadOperationDetails(resourceName.getUri());
         return BuildOperationDescriptor
-            .displayName("Download " + resourceName.getUri())
+            .displayName("Downloading " + resourceName.getUri())
             .progressDisplayName(resourceName.getShortDisplayName())
             .details(operationDetails);
     }


### PR DESCRIPTION
Updated line 61 in ProgressLoggingExternalResourceAccessor.java from Download to Downloading.

<!--- The issue this PR addresses -->
This PR addresses issue #31628.

<!-- Fixes #? -->
This PR solves issue #31628.

### Context
<!--- Why do you believe many users will benefit from this change? -->
I believe that users will benefit from this change because messages that come from Gradle Daemon will be in the right tense and they will look nicer.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
